### PR TITLE
Fix python_version format

### DIFF
--- a/nginx.json
+++ b/nginx.json
@@ -20,10 +20,7 @@
         "NGINX On-Prem - v1.15.10"
     ],
     "app_wizard_version": "1.0.0",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "configuration": {
         "base_url": {
             "description": "Base URL of NGINX Instance (Required for test connectivity)",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)